### PR TITLE
Fix compatibility across various Django/Python versions + test it with Tox

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.txt
 include *.rst
+include README.md

--- a/cache_utils/utils.py
+++ b/cache_utils/utils.py
@@ -1,3 +1,4 @@
+import six
 from hashlib import md5
 from django.utils.encoding import smart_text
 
@@ -32,7 +33,7 @@ def _args_to_unicode(args, kwargs):
 
 def _func_type(func):
     """ returns if callable is a function, method or a classmethod """
-    argnames = func.func_code.co_varnames[:func.func_code.co_argcount]
+    argnames = six.get_function_code(func).co_varnames[:six.get_function_code(func).co_argcount]
     if len(argnames) > 0:
         if argnames[0] == 'self':
             return 'method'
@@ -47,7 +48,7 @@ def _func_info(func, args):
     'cls' and 'self' removed from normalized_args '''
 
     func_type = _func_type(func)
-    lineno = ":%s" % func.func_code.co_firstlineno
+    lineno = ":%s" % six.get_function_code(func).co_firstlineno
 
     if func_type == 'function':
         name = ".".join([func.__module__, func.__name__]) + lineno

--- a/cache_utils/utils.py
+++ b/cache_utils/utils.py
@@ -25,9 +25,9 @@ def sanitize_memcached_key(key, max_length=250):
 def _args_to_unicode(args, kwargs):
     key = ""
     if args:
-        key += smart_unicode(args)
+        key += smart_text(args)
     if kwargs:
-        key += smart_unicode(kwargs)
+        key += smart_text(kwargs)
     return key
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,43 @@
 machine:
-  python:
-    version: 2.7.3
+  services:
+    - memcached
+  post:
+    - pyenv install 2.5.6
+    - pyenv install 2.6.9
+    - pyenv global 2.5.6 2.6.9 2.7.11 3.3.5 3.4.3 3.5.1
 
 dependencies:
   override:
-    - pip install django==1.4.22
-    - pip install python-memcached==1.58
-    - python setup.py develop
+    - pip install python-memcached
+    - pip install tox
 
 test:
   override:
-    - python ./test_project/runtests.py
+    - tox -e py26-dj14
+    - tox -e py26-dj15
+    - tox -e py26-dj16
+
+    - tox -e py27-dj14
+    - tox -e py27-dj15
+    - tox -e py27-dj16
+    - tox -e py27-dj17
+    - tox -e py27-dj18
+    - tox -e py27-dj19
+    - tox -e py27-dj110
+    - tox -e py27-djmaster
+
+    - tox -e py33-dj16
+    - tox -e py33-dj17
+    - tox -e py33-dj18
+
+    - tox -e py34-dj16
+    - tox -e py34-dj17
+    - tox -e py34-dj18
+    - tox -e py34-dj19
+    - tox -e py34-dj110
+    - tox -e py34-djmaster
+
+    - tox -e py35-dj18
+    - tox -e py35-dj19
+    - tox -e py35-dj110
+    - tox -e py35-djmaster

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description = """ Caching decorator and django cache backend with advanced invalidation ability and dog-pile effect prevention """,
 
     long_description = open('README.md').read(),
-    requires = ['django', 'memcached'],
+    requires = ['django', 'python_memcached'],
 
     classifiers=(
         'Development Status :: 4 - Beta',

--- a/test_project/manage.py
+++ b/test_project/manage.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+#!/usr/bin/python
+import os
+import sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/test_project/runtests.py
+++ b/test_project/runtests.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
+import os
 import sys
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
 
 sys.argv.insert(1, 'test')
 
@@ -13,5 +8,9 @@ if len(sys.argv) == 2:
     sys.argv.append('cache_utils')
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    from django.core.management import execute_from_command_line
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
 

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -15,6 +15,8 @@ CACHES = {
     },
 }
 
+SECRET_KEY="asdf"
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',  

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+
+[tox]
+envlist =
+   py26-dj{14,15,16},
+   py27-dj{14,15,16,17,18,19,110,master},
+   py33-dj{16,17,18},
+   py34-dj{17,18,19,110,master},
+   py35-dj{18,19,110,master},
+
+[testenv]
+commands =
+    pip install python-memcached
+    python --version
+    python -Wall ./test_project/runtests.py
+deps =
+    dj14: django>=1.4, <1.5
+    dj15: django>=1.5, <1.6
+    dj16: django>=1.6, <1.7
+    dj17: django>=1.7, <1.8
+    dj18: django>=1.8, <1.9
+    dj19: django>=1.9, <1.10
+    dj110: django>=1.10, <1.11
+    djmaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
This PR contains various fixes for Django/Python compatibility. The compatibility is ensured by Tox tests runned by Circle-CI. It supports Python 2.6-3.5 and Django 1.4-1.10

Running tests in Python 2.5 virtually impossible on current Circle-CI images due to it's incompatibility with Tox and other tools.