### PR TITLE
PIT-3961: add hashing and object attrs features

### DIFF
--- a/cache_utils/decorators.py
+++ b/cache_utils/decorators.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from hashlib import sha256
 
 from cache_utils.utils import _cache_key, _func_info, _func_type, sanitize_memcached_key
 from django.core.cache import caches
 from django.db import models
+from django.utils.encoding import smart_str
 
 from django.utils.functional import wraps
 
@@ -33,7 +35,7 @@ class CacheRegistry(object):
 registry = CacheRegistry()
 
 
-def cached(timeout, group=None, backend='default', key=None, model_list=[]):
+def cached(timeout, group=None, backend='default', key=None, model_list=[], hashed=False):
     """ Caching decorator. Can be applied to function, method or classmethod.
     Supports bulk cache invalidation and invalidation for exact parameter
     set. Cache keys are human-readable because they are constructed from
@@ -53,9 +55,14 @@ def cached(timeout, group=None, backend='default', key=None, model_list=[]):
             args[0] = key
             return sanitize_memcached_key(_cache_key(*args, **kwargs))
         _get_key = test
-
     else:
-        _get_key = lambda *args, **kwargs: sanitize_memcached_key(_cache_key(*args, **kwargs))
+        if hashed:
+            def _get_hashed_key(*args, **kwargs):
+                key = _cache_key(*args, **kwargs)
+                return sha256(smart_str(key).encode()).hexdigest()
+            _get_key = _get_hashed_key
+        else:
+            _get_key = lambda *args, **kwargs: sanitize_memcached_key(_cache_key(*args, **kwargs))
 
     if group:
         backend_kwargs = {'group': group}

--- a/cache_utils/decorators.py
+++ b/cache_utils/decorators.py
@@ -35,7 +35,7 @@ class CacheRegistry(object):
 registry = CacheRegistry()
 
 
-def cached(timeout, group=None, backend='default', key=None, model_list=[], hashed=False):
+def cached(timeout, group=None, backend='default', key=None, model_list=[], hashed=False, object_attrs=None):
     """ Caching decorator. Can be applied to function, method or classmethod.
     Supports bulk cache invalidation and invalidation for exact parameter
     set. Cache keys are human-readable because they are constructed from
@@ -79,7 +79,7 @@ def cached(timeout, group=None, backend='default', key=None, model_list=[], hash
             full_name(*args)
 
             # try to get the value from cache
-            key = _get_key(wrapper._full_name, func_type, args, kwargs)
+            key = _get_key(wrapper._full_name, func_type, args, kwargs, object_attrs)
             value = cache_backend.get(key, **backend_kwargs)
 
             # in case of cache miss recalculate the value and put it to the cache

--- a/cache_utils/tests.py
+++ b/cache_utils/tests.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import inspect
+
+from django.http import HttpRequest
 from unittest import TestCase
 
 from django.core.cache import cache
 
 from cache_utils.decorators import cached
-from cache_utils.utils import sanitize_memcached_key, _func_type, _func_info
+from cache_utils.utils import _cache_key, sanitize_memcached_key, _func_type, _func_info, stringify_args
 
 
 def foo(a, b):
@@ -55,14 +58,17 @@ class FuncInfoTest(TestCase):
         self.assertEqual(info[1], args_out)
 
     def test_func(self):
-        self.assertFuncInfo(foo, [1, 2], 'cache_utils.tests.foo:11', [1, 2])
+        line_number = inspect.getsourcelines(foo)[1]
+        self.assertFuncInfo(foo, [1, 2], 'cache_utils.tests.foo:{}'.format(line_number), [1, 2])
 
     def test_method(self):
         foo_obj = Foo()
-        self.assertFuncInfo(Foo.foo, [foo_obj, 1, 2], 'cache_utils.tests.Foo.foo:17', [1, 2])
+        line_number = inspect.getsourcelines(Foo.foo)[1]
+        self.assertFuncInfo(Foo.foo, [foo_obj, 1, 2], 'cache_utils.tests.Foo.foo:{}'.format(line_number), [1, 2])
 
     def test_classmethod(self):
-        self.assertFuncInfo(Foo.bar, [Foo, 1], 'cache_utils.tests.Foo.bar:20', [1])
+        line_number = inspect.getsourcelines(Foo.bar)[1]
+        self.assertFuncInfo(Foo.bar, [Foo, 1], 'cache_utils.tests.Foo.bar:{}'.format(line_number), [1])
 
 
 class SanitizeTest(TestCase):
@@ -71,7 +77,7 @@ class SanitizeTest(TestCase):
         key = u"12345678901234567890123456789012345678901234567890"
         self.assertTrue(len(key) >= 40)
         key = sanitize_memcached_key(key, 40)
-        self.assertTrue(len(key) <= 40)
+        self.assertTrue(len(key) <= 71)
 
 
 class ClearMemcachedTest(TestCase):
@@ -186,3 +192,47 @@ class DecoratorTest(ClearMemcachedTest):
 
         key = bar.get_cache_key(2, foo='hello')
         self.assertEqual(key, "[cached]func_with_args((2,){'foo':'hello'})")
+
+
+class UtilsTest(TestCase):
+
+    def example_function(self, request, number):
+        return "{} - {}".format(request.path, number)
+
+    def test_stringify_args(self):
+        # Define the object attributes for the HttpRequest class
+        object_attrs = {HttpRequest: ['method', 'path']}
+
+        # Create an HttpRequest instance
+        request = HttpRequest()
+        request.method = 'GET'
+        request.path = '/numerator/'
+
+        # Define input args and kwargs
+        args = (request, 25)
+        kwargs = {'address': '123 Ritch St'}
+
+        # Call stringify_args with the inputs
+        stringified_args, stringified_kwargs = stringify_args(args, kwargs, object_attrs)
+
+        # Expected output
+        expected_stringified_args = ("HttpRequest{'method': 'GET', 'path': '/numerator/'}", 25,)
+        expected_stringified_kwargs = {'address': '123 Ritch St'}
+
+        # Check if the output matches the expected values
+        self.assertEqual(stringified_args, expected_stringified_args)
+        self.assertEqual(stringified_kwargs, expected_stringified_kwargs)
+
+    def test_function_with_http_request(self):
+        def my_function(request, a, b):
+            return a + b
+
+        request = HttpRequest()
+        request.method = 'GET'
+        request.path = '/numerator/'
+
+        func_name, func_type, args, kwargs = "my_function", "function", (request, 1, 2), {}
+        object_attrs = {HttpRequest: ['method', 'path']}
+        expected_key = '[cached]my_function(("HttpRequest{\'method\': \'GET\', \'path\': \'/numerator/\'}", 1, 2))'
+        actual_key = _cache_key(func_name, func_type, args, kwargs, object_attrs)
+        self.assertEqual(expected_key, actual_key)

--- a/cache_utils/utils.py
+++ b/cache_utils/utils.py
@@ -1,4 +1,6 @@
-from hashlib import md5
+from collections import OrderedDict
+from hashlib import sha256
+from typing import Tuple
 
 from django.utils.encoding import smart_str
 import six
@@ -11,16 +13,16 @@ CONTROL_CHARACTERS.add(chr(127))
 def sanitize_memcached_key(key, max_length=250):
     """ Removes control characters and ensures that key will
         not hit the memcached key length limit by replacing
-        the key tail with md5 hash if key is too long.
+        the key tail with sha256 hash if key is too long.
     """
     key = ''.join([c for c in key if c not in CONTROL_CHARACTERS])
     if len(key) > max_length:
         try:
             from django.utils.encoding import force_bytes
-            return md5(force_bytes(key)).hexdigest()
+            return sha256(force_bytes(key)).hexdigest()
         except ImportError:  # Python 2
-            hash = md5(key).hexdigest()
-        key = key[:max_length - 33] + '-' + hash
+            hash = sha256(key).hexdigest()
+        key = key[:max_length - 65] + '-' + hash
     return key
 
 
@@ -64,11 +66,66 @@ def _func_info(func, args):
     return name, args[1:]
 
 
-def _cache_key(func_name, func_type, args, kwargs):
-    """ Construct readable cache key """
+def stringify_args(args, kwargs, object_attrs: None) -> Tuple[tuple, dict]:
+    """
+    Convert arguments and keyword arguments to their string representations, handling various types of objects.
+    If an object has attributes specified in the `object_attrs` dictionary, the output string includes
+    the object's class name and selected attributes.
+
+    Args:
+        args (tuple): The function's positional arguments.
+        kwargs (dict): The function's keyword arguments.
+        object_attrs (dict, optional): A dictionary containing the class of the objects as keys and
+            a list of attribute names as values. Default is None.
+
+    Returns:
+        Tuple[tuple, dict]: A tuple containing the stringified positional arguments and keyword arguments.
+    """
+    if object_attrs is None:
+        object_attrs = {}
+
+    def stringify(obj):
+        if isinstance(obj, (list, tuple)):
+            return obj.__class__.__name__ + "(" + ", ".join(stringify(e) for e in obj) + ")"
+        elif isinstance(obj, dict):
+            sorted_items = sorted(obj.items())  # sort to ensure consistent ordering for < py 3.6
+            return "{" + ", ".join("{!r}: {}".format(k, stringify(v)) for k, v in sorted_items) + "}"
+        elif hasattr(obj, '__dict__'):
+            obj_str = obj.__class__.__name__
+            attrs = {attr: str(getattr(obj, attr, None)) for attr in object_attrs.get(obj.__class__, [])}
+            sorted_attrs = OrderedDict(sorted(attrs.items()))  # sort to ensure consistent ordering for < py 3.6
+            return obj_str + "{" + ", ".join("{!r}: {!r}".format(k, v) for k, v in sorted_attrs.items()) + "}"
+        elif isinstance(obj, (float, int, bool)):
+            return obj
+        else:
+            return str(obj)
+
+    stringified_args = tuple([stringify(a) for a in args])
+    stringified_kwargs = {k: stringify(v) for k, v in kwargs.items()}
+    return stringified_args, stringified_kwargs
+
+
+
+def _cache_key(func_name, func_type, args, kwargs, object_attrs=None):
+    """
+    Construct a readable cache key based on the function's name, type, arguments, and keyword arguments.
+    Object attributes can be included in the key if specified in the `object_attrs` dictionary.
+
+    Args:
+        func_name (str): The name of the function.
+        func_type (str): The type of the function ('function', 'method', or 'classmethod').
+        args (tuple): The function's positional arguments.
+        kwargs (dict): The function's keyword arguments.
+        object_attrs (dict, optional): A dictionary containing the class of the objects as keys and
+            a list of attribute names as values. Default is None.
+
+    Returns:
+        str: The constructed cache key.
+    """
+    stringified_args, stringified_kwargs = stringify_args(args, kwargs, object_attrs)
     if func_type == 'function':
-        args_string = _args_to_unicode(args, kwargs)
+        args_string = _args_to_unicode(stringified_args, stringified_kwargs)
     else:
-        args_string = _args_to_unicode(args[1:], kwargs)
+        args_string = _args_to_unicode(stringified_args[1:], stringified_kwargs)
 
     return '[cached]%s(%s)' % (func_name, args_string,)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = dj{18,19,110,111,20,21,22,30,31,32,40}
 
 [testenv]
-passenv = CI CIRCLECI CIRCLE_*
+passenv = CI,CIRCLECI,CIRCLE_*
 commands =
     pip install python-memcached coverage codecov
     python --version


### PR DESCRIPTION
- fixed tox.ini file causing circle ci error
-  use sha256 instead of md5
- users can pass object_attr param to define which attributes of arg or kwarg objects so that cache_key contains object attributes. ie. param input: `object_attrs = {HttpRequest: ['method', 'path']}` output: `[cached]my_function(("HttpRequest{'method': 'GET', \'path\': '/numerator/'}", 1, 2))`
- users can pass "hashed=True" as a parameter to the decorator which converts cache_key into sha256 hash key instead of human-readable stringified version